### PR TITLE
feat(online-boutique): protect a sample endpoint with oauth2-proxy

### DIFF
--- a/online-boutique/kustomize/frontend-admin-panel.yaml
+++ b/online-boutique/kustomize/frontend-admin-panel.yaml
@@ -1,0 +1,44 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: frontend-admin-panel
+data:
+  index.html: |
+    <!DOCTYPE html>
+    <html lang="en">
+    <head>
+        <meta charset="UTF-8">
+        <meta name="viewport" content="width=device-width, initial-scale=1.0">
+        <title>Administration - Cymbal Shop</title>
+        <script src="https://cdn.tailwindcss.com"></script>
+    </head>
+    <body class="flex flex-col min-h-screen bg-gray-50 font-sans antialiased">
+        <nav class="bg-white shadow">
+            <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
+                <div class="flex justify-between h-16">
+                    <div class="flex">
+                        <a href="/" class="flex-shrink-0 flex items-center">
+                            <img class="h-8 w-auto" src="/static/icons/Cymbal_NavLogo.svg" alt="Cymbal Shop Logo">
+                        </a>
+                    </div>
+                    <div class="flex items-center space-x-4">
+                        <a href="#" class="text-gray-700 hover:text-gray-900">Dashboard</a>
+                        <a href="#" class="text-gray-700 hover:text-gray-900">Products</a>
+                        <a href="#" class="text-gray-700 hover:text-gray-900">Ads</a>
+                    </div>
+                </div>
+            </div>
+        </nav>
+        <main class="flex-grow mt-8 mx-auto max-w-7xl px-4 sm:px-6 lg:px-8">
+            <div class="bg-white rounded-lg shadow-lg p-6">
+                <h1 class="text-2xl font-bold text-gray-800 mb-4">Shop Administration</h1>
+                <p class="text-gray-600 mb-6">Welcome to the admin panel! Our goal: keep the shop running smoothly and make sure no cymbals are harmed in the process.</p>
+            </div>
+        </main>
+        <footer class="bg-gray-100">
+            <div class="max-w-7xl mx-auto px-4 py-4 sm:px-6 lg:px-8 text-center text-gray-500">
+                &copy; 2024 Cymbal Shop. All rights reserved.
+            </div>
+        </footer>
+    </body>
+    </html>

--- a/online-boutique/kustomize/ingress.yaml
+++ b/online-boutique/kustomize/ingress.yaml
@@ -8,6 +8,10 @@ metadata:
     forecastle.stakater.com/appName: "Shop"
     forecastle.stakater.com/group: "Apps"
     forecastle.stakater.com/icon: "https://raw.githubusercontent.com/GoogleCloudPlatform/microservices-demo/b6ab75e675ea1e1c3b856327d6116b832b60e88f/src/frontend/static/icons/Cymbal_NavLogo.svg"
+    # Inject an admin link
+    nginx.ingress.kubernetes.io/configuration-snippet: |
+      proxy_set_header Accept-Encoding ""; # The http_sub_module doesn't support compression from the ingress to the backend application
+      sub_filter "</body>" "<script>(function(){document.addEventListener('DOMContentLoaded',function(){document.body.insertAdjacentHTML('beforeend','<a href=\"/static/admin\" style=\"position:fixed;bottom:10px;right:10px;background-color:#2c0678;color:white;padding:5px;border-radius:3px;text-decoration:none;font-family:sans-serif;\">Admin</a>')})})()</script></body>";
 spec:
   ingressClassName: ref+file://config.yaml#/ingress/defaultClass+
   rules:
@@ -53,7 +57,7 @@ spec:
             name: frontend
             port:
               name: http
-        path: /admin
+        path: /static/admin/
         pathType: Prefix
   tls:
   - hosts:

--- a/online-boutique/kustomize/ingress.yaml
+++ b/online-boutique/kustomize/ingress.yaml
@@ -11,17 +11,47 @@ metadata:
 spec:
   ingressClassName: ref+file://config.yaml#/ingress/defaultClass+
   rules:
-    - host: shop.ref+file://config.yaml#/ingress/domainName+
-      http:
-        paths:
-          - path: /
-            pathType: Prefix
-            backend:
-              service:
-                name: frontend
-                port:
-                  name: http
+  - host: shop.ref+file://config.yaml#/ingress/domainName+
+    http:
+      paths:
+      - path: /
+        pathType: Prefix
+        backend:
+          service:
+            name: frontend
+            port:
+              name: http
   tls:
-    - hosts:
-      - shop.ref+file://config.yaml#/ingress/domainName+
-      secretName: tls-online-boutique
+  - hosts:
+    - shop.ref+file://config.yaml#/ingress/domainName+
+    secretName: tls-online-boutique
+---
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: frontend-protected
+  annotations:
+    cert-manager.io/cluster-issuer: ref+file://config.yaml#/ingress/defaultClusterIssuer+
+    nginx.ingress.kubernetes.io/auth-url: http://oauth2-proxy.k8saas-system.svc.cluster.local/oauth2/auth
+    nginx.ingress.kubernetes.io/auth-signin: https://oauth2-proxy.ref+file://config.yaml#/ingress/domainName+/oauth2/sign_in
+    # Inject a logout button
+    nginx.ingress.kubernetes.io/configuration-snippet: |
+      proxy_set_header Accept-Encoding ""; # The http_sub_module doesn't support compression from the ingress to the backend application
+      sub_filter "</body>" "<script>(function(){document.addEventListener('DOMContentLoaded',function(){document.body.insertAdjacentHTML('beforeend','<a href=\"https://oauth2-proxy.ref+file://config.yaml#/ingress/domainName+/oauth2/sign_out?rd=https://shop.ref+file://config.yaml#/ingress/domainName+\" style=\"position:fixed;bottom:10px;right:10px;background-color:#f44336;color:white;padding:5px;border-radius:3px;text-decoration:none;font-family:sans-serif;\">Logout</a>')})})()</script></body>";  name: frontend-protected
+spec:
+  ingressClassName: ref+file://config.yaml#/ingress/defaultClass+
+  rules:
+  - host: shop.ref+file://config.yaml#/ingress/domainName+
+    http:
+      paths:
+      - backend:
+          service:
+            name: frontend
+            port:
+              name: http
+        path: /cart
+        pathType: Prefix
+  tls:
+  - hosts:
+    - shop.ref+file://config.yaml#/ingress/domainName+
+    secretName: tls-online-boutique

--- a/online-boutique/kustomize/ingress.yaml
+++ b/online-boutique/kustomize/ingress.yaml
@@ -32,12 +32,16 @@ metadata:
   name: frontend-admin
   annotations:
     cert-manager.io/cluster-issuer: ref+file://config.yaml#/ingress/defaultClusterIssuer+
+    forecastle.stakater.com/expose: "true"
+    forecastle.stakater.com/appName: "Shop Admin"
+    forecastle.stakater.com/group: "Apps"
+    forecastle.stakater.com/icon: "https://raw.githubusercontent.com/GoogleCloudPlatform/microservices-demo/b6ab75e675ea1e1c3b856327d6116b832b60e88f/src/frontend/static/icons/Cymbal_NavLogo.svg"
     nginx.ingress.kubernetes.io/auth-url: http://oauth2-proxy.k8saas-system.svc.cluster.local/oauth2/auth
     nginx.ingress.kubernetes.io/auth-signin: https://oauth2-proxy.ref+file://config.yaml#/ingress/domainName+/oauth2/sign_in
     # Inject a logout button
     nginx.ingress.kubernetes.io/configuration-snippet: |
       proxy_set_header Accept-Encoding ""; # The http_sub_module doesn't support compression from the ingress to the backend application
-      sub_filter "</body>" "<script>(function(){document.addEventListener('DOMContentLoaded',function(){document.body.insertAdjacentHTML('beforeend','<a href=\"https://oauth2-proxy.ref+file://config.yaml#/ingress/domainName+/oauth2/sign_out?rd=https://shop.ref+file://config.yaml#/ingress/domainName+\" style=\"position:fixed;bottom:10px;right:10px;background-color:#f44336;color:white;padding:5px;border-radius:3px;text-decoration:none;font-family:sans-serif;\">Logout</a>')})})()</script></body>";  name: frontend-protected
+      sub_filter "</body>" "<script>(function(){document.addEventListener('DOMContentLoaded',function(){document.body.insertAdjacentHTML('beforeend','<a href=\"https://oauth2-proxy.ref+file://config.yaml#/ingress/domainName+/oauth2/sign_out?rd=https://shop.ref+file://config.yaml#/ingress/domainName+\" style=\"position:fixed;bottom:10px;right:10px;background-color:#f44336;color:white;padding:5px;border-radius:3px;text-decoration:none;font-family:sans-serif;\">Logout</a>')})})()</script></body>";
 spec:
   ingressClassName: ref+file://config.yaml#/ingress/defaultClass+
   rules:

--- a/online-boutique/kustomize/ingress.yaml
+++ b/online-boutique/kustomize/ingress.yaml
@@ -29,7 +29,7 @@ spec:
 apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
-  name: frontend-protected
+  name: frontend-admin
   annotations:
     cert-manager.io/cluster-issuer: ref+file://config.yaml#/ingress/defaultClusterIssuer+
     nginx.ingress.kubernetes.io/auth-url: http://oauth2-proxy.k8saas-system.svc.cluster.local/oauth2/auth
@@ -49,7 +49,7 @@ spec:
             name: frontend
             port:
               name: http
-        path: /cart
+        path: /admin
         pathType: Prefix
   tls:
   - hosts:

--- a/online-boutique/kustomize/kustomization.yaml
+++ b/online-boutique/kustomize/kustomization.yaml
@@ -3,6 +3,7 @@ kind: Kustomization
 namespace: online-boutique
 resources:
 - https://github.com/GoogleCloudPlatform/microservices-demo//kustomize/base?ref=6af73dcf7fe1ca653d95ae7a29e12faf8cf02964
+- frontend-admin-panel.yaml
 - ingress.yaml
 - dashboard.yaml
 - slo.yaml
@@ -13,3 +14,4 @@ components:
 - https://github.com/GoogleCloudPlatform/microservices-demo//kustomize/components/cymbal-branding?ref=6af73dcf7fe1ca653d95ae7a29e12faf8cf02964
 patches:
 - path: patch-enable-tracing.yaml
+- path: patch-frontend-admin-panel.yaml

--- a/online-boutique/kustomize/patch-frontend-admin-panel.yaml
+++ b/online-boutique/kustomize/patch-frontend-admin-panel.yaml
@@ -1,0 +1,16 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: frontend
+spec:
+  template:
+    spec:
+      containers:
+        - name: server
+          volumeMounts:
+            - mountPath: /src/static/admin
+              name: frontend-admin-panel
+      volumes:
+        - name: frontend-admin-panel
+          configMap:
+            name: frontend-admin-panel


### PR DESCRIPTION
Closes https://github.com/ccl-consulting/k8saas/issues/507

~The only issue I see with this is, when logged out, the "add to card" button redirects to auth, then auth redirects to an empty cart.~
~Once logged in, add to cart works well.~
~To hide this weird behavior, either put the whole app behind the wall, protect an other page (dunno which one?), or click on show cart first so the login is done before posts to /cart.~

Changed to protect a sample admin page.
![Screenshot from 2024-11-07 12-19-27](https://github.com/user-attachments/assets/5eb4c694-2f5f-4b7a-a576-75dd07f9e178)
![Screenshot from 2024-11-07 12-19-37](https://github.com/user-attachments/assets/b7d00838-c88e-4833-8550-c376b500299f)
![Screenshot from 2024-11-07 12-19-44](https://github.com/user-attachments/assets/82da812f-e4fe-4b02-997a-0f35f3defc99)
